### PR TITLE
Allow sync run to be scheduled.

### DIFF
--- a/src/Scheduler.js
+++ b/src/Scheduler.js
@@ -72,17 +72,18 @@ class Queue extends Emitter {
 
     this.workingTask_ = task;
 
-    const potentialPromise = task.run();
-
     const completeWork = () => {
       this.workingTask_ = null;
       this.dequeue();
     };
 
-    if (typeof potentialPromise?.then === "function") {
-      potentialPromise.then(completeWork);
+    // The return value of a task run should not be
+    // async by definition, it might aswell be sync, or undefined.
+    const value = task.run();
+    if (value instanceof Promise) {
+      value.then(completeWork);
     } else {
-      completeWork(potentialPromise);
+      completeWork();
     }
   }
 

--- a/src/Scheduler.js
+++ b/src/Scheduler.js
@@ -72,10 +72,18 @@ class Queue extends Emitter {
 
     this.workingTask_ = task;
 
-    task.run().then(() => {
+    const potentialPromise = task.run();
+
+    const completeWork = () => {
       this.workingTask_ = null;
       this.dequeue();
-    });
+    };
+
+    if (typeof potentialPromise?.then === "function") {
+      potentialPromise.then(completeWork);
+    } else {
+      completeWork(potentialPromise);
+    }
   }
 
   flush() {


### PR DESCRIPTION
The following code would result in an exception:

```javascript
const syncTask = () => {};
scheduler.scheduleCallback(syncTask);
```

Due to the fact that the return value of `task.run()` expects a `then()` callback.